### PR TITLE
Fixed mandatory space around operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: all test dependencies targets
 
 SOURCES := $(shell find . -type f -name '*.go')
+PEGS := $(shell find . -type f -name '*.peg')
+
 TARGETS := \
 	linux-386 \
 	linux-amd64 \
@@ -8,11 +10,14 @@ TARGETS := \
 
 TARGET_DIR := target
 PROGRAMS := $(foreach target,$(TARGETS),$(TARGET_DIR)/logan-$(target))
+GENERATED_PEGS := $(PEGS:.peg=.peg.go)
 
-all: test targets
+all: parsers test targets
 
 dependencies:
 	go get -v
+
+parsers: $(GENERATED_PEGS)
 
 test: dependencies
 	find . -type d -not -path '*/.git*' -a -not -path '*/target*' -a -not -path '*/docs*' | \
@@ -30,3 +35,6 @@ $(PROGRAMS): $(SOURCES)
 	GOOS=$$(echo "$@" | xargs basename | cut -d- -f2) \
 	GOARCH=$$(echo "$@" | xargs basename | cut -d- -f3) \
 	go build -v -o "$@" .
+
+%.peg.go: %.peg
+	peg $<

--- a/filter/columnfilter.peg
+++ b/filter/columnfilter.peg
@@ -7,9 +7,9 @@ type ColumnFilterParser Peg {
 filterExpression <- { p.Expr = &Expression{} }
                     andFilterExpression
                     (
-                      ws
+                      ws+
                       orOperator
-                      ws
+                      ws+
                       { p.Expr = p.Expr.PushLeftGoRight(OpOr) }
                       andFilterExpression
                       { p.Expr = p.Expr.GoUp() }
@@ -18,9 +18,9 @@ filterExpression <- { p.Expr = &Expression{} }
 
 andFilterExpression <- columnFilterExpression
                        (
-                         ws
+                         ws+
                          andOperator
-                         ws
+                         ws+
                          { p.Expr = p.Expr.PushLeftGoRight(OpAnd) }
                          columnFilterExpression
                          { p.Expr = p.Expr.GoUp() }
@@ -30,10 +30,10 @@ columnFilterExpression <- relation
 relation <- ( { p.Expr = p.Expr.GoLeft() }
               expression
               { p.Expr = p.Expr.GoUp() }
-              ws
+              ws*
               { p.Expr.SetType(TypeRelation) }
               relationOperator
-              ws
+              ws*
               { p.Expr = p.Expr.GoRight() }
               expression
               { p.Expr = p.Expr.GoUp() }

--- a/filter/columnfilter_test.go
+++ b/filter/columnfilter_test.go
@@ -52,6 +52,12 @@ func TestSimpleEqualFilterWorks(t *testing.T) {
 
 }
 
+func TestSimpleEqualFilterWorksWithoutSpaces(t *testing.T) {
+	testFilter(t, "$3==\"teststring\"",
+		expectMatch("", "", "teststring"),
+		expectDoesntMatch("", "", "string"))
+}
+
 func TestShouldNotPanicIfColumnIndexIsWrong(t *testing.T) {
 	testFilter(t, "$4 == \"teststring\"",
 		expectDoesntMatch("", "", "teststring"))


### PR DESCRIPTION
This PR fixes #3 by using `ws*` around operators. Additionally, it makes possible to use more spaces around logical operators `AND` and `OR`, but I didn't feel the need to add test for that.